### PR TITLE
Set up CI/CD pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Run unit tests
+name: Build and test
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Poetry
+      run: |
+        python -m pip install --upgrade pip
+        pip install --user poetry
+    - name: Install dependencies
+      run: |
+        poetry install
+    - name: Run tests
+      run: |
+        poetry run pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Run unit tests
 
 on:
   push:
@@ -23,10 +23,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Poetry
+    - name: Install poetry
+      shell: bash
       run: |
-        python -m pip install --upgrade pip
-        pip install --user poetry
+        curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
+        python get-poetry.py --preview -y
+        echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
     - name: Install dependencies
       run: |
         poetry install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    - name: Install Poetry
+      run: |
+        python -m pip install --upgrade pip
+        pip install --user poetry
+    - name: Install dependencies
+      run: |
+        poetry install
+    - name: Build and publish
+      env:
+        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        poetry publish --build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,13 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install
+    - name: Set version
+      run: |
+        poetry version ${GITHUB_REF##*/}
+        sed -i "s/'1.0.dev0'/'${GITHUB_REF##*/}'/g" clin/__init__.py
+    - name: Run tests
+      run: |
+        poetry run pytest
     - name: Build and publish
       env:
         POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 # This workflows will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: Upload Python Package
+name: Publish to PyPI
 
 on:
   release:
@@ -18,10 +18,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-    - name: Install Poetry
+    - name: Install poetry
+      shell: bash
       run: |
-        python -m pip install --upgrade pip
-        pip install --user poetry
+        curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
+        python get-poetry.py --preview -y
+        echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
     - name: Install dependencies
       run: |
         poetry install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:

--- a/clin/__init__.py
+++ b/clin/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.0.0'
+__version__ = '1.0.dev0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "clin"
-version = "1.0.0"
+version = "1.0.dev0"
 description = "Cli for Nakadi resources management in infrastructure-as-a-code manner"
 homepage = "https://github.bus.zalan.do/derokhin/clin"
 license = "MIT"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,7 +40,7 @@ def test_loads_auth_as_flat_lists_without_duplicates():
         write: true
     """
 
-    spec = yaml.load(yml)
+    spec = yaml.safe_load(yml)
     auth = Auth.from_spec(spec["auth"])
 
     assert auth.users.admins == ["hammond"]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,6 +6,3 @@ from clin import __version__
 def test_pyproject_version_matches_package_version():
     pyproj = toml.load("pyproject.toml")
     assert __version__ == pyproj["tool"]["poetry"]["version"]
-
-def test_this_test_fails():
-    assert "lorem" == "ipsum"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,3 +6,6 @@ from clin import __version__
 def test_pyproject_version_matches_package_version():
     pyproj = toml.load("pyproject.toml")
     assert __version__ == pyproj["tool"]["poetry"]["version"]
+
+def test_this_test_fails():
+    assert "lorem" == "ipsum"


### PR DESCRIPTION
# One-line summary
Part of #4 - Set up CI/CD pipeline to build, test and publish to PyPI

## Description
Set up a pipeline that builds and tests all pull requests. When a release is created, the app is packaged and pushed to PyPI: https://pypi.org/project/clin. It does so by taking the version from the release tag and for the time being requires those tags to be created manually. 
Note that the publishing script is untested because there is no tag yet. I'm _somewhat_ confident that it will work as-is.

## Types of Changes
- Documentation / non-code
