### PR TITLE
fix set version to work with blacked file

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set version
       run: |
         poetry version ${GITHUB_REF##*/}
-        sed -i "s/'1.0.dev0'/'${GITHUB_REF##*/}'/g" clin/__init__.py
+        sed -i "s/\"1.0.dev0\"/\"${GITHUB_REF##*/}\"/g" clin/__init__.py
     - name: Run linter
       run: |
         poetry run black clin --check


### PR DESCRIPTION
`sed` broke because black has reformatted the `__init__` file. my bad. 

That's a clear indication that the pipeline is too fragile; will try to fix asap.