### PR TITLE
bump development status to 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Natural Language :: English",


### PR DESCRIPTION
# One-line summary
Since we've been live with 1.0.0 for a subjectively very long time, I think it's appropriate to bump the development status. See https://pypi.org/classifiers/