### PR TITLE
Fixed bug wit retention time field  for the log-compacted event types

### DIFF
--- a/clin/models/event_type.py
+++ b/clin/models/event_type.py
@@ -58,7 +58,7 @@ class Cleanup:
             return str(self.value)
 
     policy: Policy
-    retention_time_days: Optional[int]
+    retention_time_days: int
 
 
 @dataclass

--- a/clin/nakadi.py
+++ b/clin/nakadi.py
@@ -187,11 +187,6 @@ def event_type_to_payload(event_type: EventType) -> dict:
     enrichment_strategies = (
         [] if event_type.category == Category.UNDEFINED else ["metadata_enrichment"]
     )
-    options = (
-        {}
-        if event_type.cleanup.policy == Cleanup.Policy.COMPACT
-        else {"retention_time": event_type.cleanup.retention_time_days * MS_IN_DAY}
-    )
     return {
         "name": event_type.name,
         "owning_application": event_type.owning_application,
@@ -206,7 +201,9 @@ def event_type_to_payload(event_type: EventType) -> dict:
             "write_parallelism": event_type.partitioning.partition_count,
         },
         "cleanup_policy": event_type.cleanup.policy,
-        "options": options,
+        "options": {
+            "retention_time": event_type.cleanup.retention_time_days * MS_IN_DAY
+        },
         "compatibility_mode": event_type.schema.compatibility,
         "schema": {
             "type": "json_schema",


### PR DESCRIPTION
# One-line summary
> Issue : #11 
- Made retention time non-optional in data class model
- Fix event type payload generation to always fill `retention_time`

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
