### PR TITLE
add `id` and `env` options to `process`

### DIFF
--- a/clin/clinfile.py
+++ b/clin/clinfile.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass
 from itertools import chain
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 from clin.yamlops import YamlLoader
 
@@ -16,17 +16,26 @@ class Process:
     target: str
 
 
-def calculate_scope(master: dict, base_path: Path, loader: YamlLoader) -> List[Process]:
+def calculate_scope(
+    master: dict,
+    base_path: Path,
+    loader: YamlLoader,
+    filter_id: Tuple[str],
+    filter_env: Tuple[str],
+) -> List[Process]:
     processes = master.get("process")
     if not processes:
         raise Exception("'process' section is not found")
 
     scope = []
     for proc in processes:
-        proc_id = proc["id"]
-        proc_paths = proc["paths"]
+        if len(filter_id) > 0 and proc["id"] not in filter_id:
+            continue
+        if len(filter_env) > 0 and proc["target"] not in filter_env:
+            continue
 
-        sources = [base_path.joinpath(s).resolve(strict=False) for s in proc_paths]
+        proc_id = proc["id"]
+        sources = [base_path.joinpath(s).resolve(strict=False) for s in proc["paths"]]
         manifests_files = []
         for source in sources:
             if not source.exists():

--- a/clin/run.py
+++ b/clin/run.py
@@ -153,7 +153,7 @@ def apply(
     required=False,
     type=str,
     multiple=True,
-    help="Select one or multiple steps to process by mathing the target environment",
+    help="Select one or multiple steps to process by matching the target environment",
 )
 @click.argument("file", type=click.Path(exists=True, dir_okay=False, readable=True))
 def process(


### PR DESCRIPTION
# One-line summary

Allow filtering the `process` operation by id and env

## Types of Changes

- New feature (non-breaking change which adds functionality)
