### PR TITLE
add envelope option to dump

### DIFF
--- a/clin/run.py
+++ b/clin/run.py
@@ -149,6 +149,12 @@ def process(
     help="Output format",
 )
 @click.option(
+    "--include-envelope",
+    is_flag=True,
+    default=False,
+    help="Add clin envelope to schema (default - false)",
+)
+@click.option(
     "-v",
     "--verbose",
     is_flag=True,
@@ -156,7 +162,14 @@ def process(
     help="Verbose output (default - false)",
 )
 @click.argument("event_type", type=str)
-def dump(env: str, token: Optional[str], output: str, verbose: bool, event_type: str):
+def dump(
+    env: str,
+    token: Optional[str],
+    output: str,
+    include_envelope: bool,
+    verbose: bool,
+    event_type: str,
+):
     """Print manifest of existing Nakadi event type"""
     configure_logging(verbose)
 
@@ -172,10 +185,19 @@ def dump(env: str, token: Optional[str], output: str, verbose: bool, event_type:
             logging.error("Event type not found in Nakadi %s: %s", env, event_type)
             exit(-1)
 
+        et_output = (
+            et.to_spec()
+            if not include_envelope
+            else {
+                "kind": "event-type",
+                "spec": et.to_spec(),
+            }
+        )
+
         if output.lower() == "yaml":
-            logging.info(pretty_yaml(et.to_spec()))
+            logging.info(pretty_yaml(et_output))
         elif output.lower() == "json":
-            logging.info(pretty_json(et.to_spec()))
+            logging.info(pretty_json(et_output))
         else:
             logging.error("Invalid output format: %s", output)
             exit(-1)


### PR DESCRIPTION
# One-line summary

Add `--include-envelope` switch to `dump` to wrap the event type in the clin envelope.

## Description

New output with flag:

```
❯ clin dump -e production -t $(ztoken) --include-envelope my-event
kind: event-type
spec:
  name: my-event
  category: business
...
```

Existing output without flag unchanged:

```
❯ clin dump -e production -t $(ztoken) --include-envelope my-event
name: my-event
category: business
...
```

Same functionality for JSON output

```
❯ clin dump -e production -t $(ztoken) --include-envelope -o json my-event
{
  "kind": "event-type",
  "spec": {
    "name": "my-event",
...
```
## Types of Changes

- New feature (non-breaking change which adds functionality)