### PR TITLE
add explicit build step to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run linter
         run: poetry run black clin --check
 
+      - name: Build packages
+        run: poetry build
+
       - name: Run tests
         run: poetry run pytest
 


### PR DESCRIPTION
# One-line summary

This should (hopefully) fix the publish step that only happens on release: https://github.com/zalando-incubator/clin/runs/1986700174?check_suite_focus=true


## Types of Changes
- Bug fix (non-breaking change which fixes an issue)

## Review

Unfortunately I can only tell for sure that this works when building/publishing the actual release. I will republish 1.1.0 once this is merged.
