### PR TITLE
Fixed updating statistics bug

### DIFF
--- a/clin/clients/nakadi.py
+++ b/clin/clients/nakadi.py
@@ -59,7 +59,9 @@ class Nakadi(HttpClient):
     def update_event_type(self, event_type: EventType):
         resp = self._put(
             f"event-types/{event_type.name}",
-            data=json.dumps(event_type_to_payload(event_type, include_statistics=False)),
+            data=json.dumps(
+                event_type_to_payload(event_type, include_statistics=False)
+            ),
         )
         if resp.status_code != 200:
             raise NakadiError(
@@ -67,7 +69,7 @@ class Nakadi(HttpClient):
             )
 
     def get_subscription(
-            self, event_types: List, owning_application: str, consumer_group: str
+        self, event_types: List, owning_application: str, consumer_group: str
     ) -> Optional[Subscription]:
         params_str = Subscription.components_string(
             event_types, owning_application, consumer_group
@@ -141,7 +143,9 @@ class NakadiError(Exception):
                 return msg
 
 
-def event_type_to_payload(event_type: EventType, include_statistics: bool = True) -> dict:
+def event_type_to_payload(
+    event_type: EventType, include_statistics: bool = True
+) -> dict:
     enrichment_strategies = (
         [] if event_type.category == Category.UNDEFINED else ["metadata_enrichment"]
     )
@@ -160,7 +164,6 @@ def event_type_to_payload(event_type: EventType, include_statistics: bool = True
         "audience": str(event_type.audience),
         "partition_strategy": str(event_type.partitioning.strategy),
         "partition_key_fields": event_type.partitioning.keys,
-
         "cleanup_policy": event_type.cleanup.policy,
         "options": {
             "retention_time": event_type.cleanup.retention_time_days * MS_IN_DAY
@@ -193,7 +196,7 @@ def event_type_from_payload(payload: dict, partition_count: int) -> EventType:
         cleanup=Cleanup(
             policy=Cleanup.Policy(payload["cleanup_policy"]),
             retention_time_days=payload["options"].get("retention_time", 0)
-                                // MS_IN_DAY,
+            // MS_IN_DAY,
         ),
         schema=Schema(
             compatibility=Schema.Compatibility(payload["compatibility_mode"]),

--- a/clin/clients/nakadi.py
+++ b/clin/clients/nakadi.py
@@ -59,7 +59,7 @@ class Nakadi(HttpClient):
     def update_event_type(self, event_type: EventType):
         resp = self._put(
             f"event-types/{event_type.name}",
-            data=json.dumps(event_type_to_payload(event_type)),
+            data=json.dumps(event_type_to_payload(event_type, include_statistics=False)),
         )
         if resp.status_code != 200:
             raise NakadiError(
@@ -67,7 +67,7 @@ class Nakadi(HttpClient):
             )
 
     def get_subscription(
-        self, event_types: List, owning_application: str, consumer_group: str
+            self, event_types: List, owning_application: str, consumer_group: str
     ) -> Optional[Subscription]:
         params_str = Subscription.components_string(
             event_types, owning_application, consumer_group
@@ -141,23 +141,26 @@ class NakadiError(Exception):
                 return msg
 
 
-def event_type_to_payload(event_type: EventType) -> dict:
+def event_type_to_payload(event_type: EventType, include_statistics: bool = True) -> dict:
     enrichment_strategies = (
         [] if event_type.category == Category.UNDEFINED else ["metadata_enrichment"]
     )
-    return {
-        "name": event_type.name,
-        "owning_application": event_type.owning_application,
-        "category": str(event_type.category),
-        "audience": str(event_type.audience),
-        "partition_strategy": str(event_type.partitioning.strategy),
-        "partition_key_fields": event_type.partitioning.keys,
+    default_statistic_part = {
         "default_statistic": {
             "messages_per_minute": 100,
             "message_size": 100,
             "read_parallelism": event_type.partitioning.partition_count,
             "write_parallelism": event_type.partitioning.partition_count,
         },
+    }
+    payload = {
+        "name": event_type.name,
+        "owning_application": event_type.owning_application,
+        "category": str(event_type.category),
+        "audience": str(event_type.audience),
+        "partition_strategy": str(event_type.partitioning.strategy),
+        "partition_key_fields": event_type.partitioning.keys,
+
         "cleanup_policy": event_type.cleanup.policy,
         "options": {
             "retention_time": event_type.cleanup.retention_time_days * MS_IN_DAY
@@ -171,6 +174,9 @@ def event_type_to_payload(event_type: EventType) -> dict:
         "authorization": auth_to_payload(event_type.auth),
         "enrichment_strategies": enrichment_strategies,
     }
+    if include_statistics:
+        payload.update(default_statistic_part)
+    return payload
 
 
 def event_type_from_payload(payload: dict, partition_count: int) -> EventType:
@@ -187,7 +193,7 @@ def event_type_from_payload(payload: dict, partition_count: int) -> EventType:
         cleanup=Cleanup(
             policy=Cleanup.Policy(payload["cleanup_policy"]),
             retention_time_days=payload["options"].get("retention_time", 0)
-            // MS_IN_DAY,
+                                // MS_IN_DAY,
         ),
         schema=Schema(
             compatibility=Schema.Compatibility(payload["compatibility_mode"]),


### PR DESCRIPTION
## Description
There is a field of event type `default_statistics`. Content of this field defines the number of partitions to be created for a new event type. And then this part is can not be changed.

In some cases, Nakadi can store `null` for its field after the event-type was created.

Proper default statiscits:
![image](https://user-images.githubusercontent.com/283266/116068586-b0646800-a68a-11eb-8e39-1afd0e9a2a08.png)

Absent default statistics:
![image](https://user-images.githubusercontent.com/283266/116068506-9a56a780-a68a-11eb-9689-5f4c818a9b33.png)


For such event types updating event type is failing, because Nakadi considers this as an update of the field, which is prohibited. To overcome the issue current change propose to send the field only when the event type is created. 

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
