### PR TITLE
Call super correctly to avoid uncaught exceptions during error handling

### DIFF
--- a/clin/yamlops.py
+++ b/clin/yamlops.py
@@ -147,7 +147,7 @@ class YamlIncorrectSubstitutionError(YamlError):
 
 class YamlInvalidFormatError(YamlError):
     def __init__(self, file: Path, message: str):
-        super(file)
+        super(YamlInvalidFormatError, self).__init__(file)
         self.message = message
 
     def __str__(self):


### PR DESCRIPTION
# One-line summary

Fixes error message displayed to user when the config file does not contain required fields.

## Description

When the user tries to apply a manifest file with invalid format (eg. that doesn't contain required field `kind`), following output is returned:

```
$ clin apply -e staging --token "$TOKEN" ./manifest-without-kind.yaml 
super() argument 1 must be type, not PosixPath
Traceback (most recent call last):
  File "/home/dlippok/.local/lib/python3.8/site-packages/clin/yamlops.py", line 164, in load_manifest
    return Envelope.from_manifest(manifest)
  File "/home/dlippok/.local/lib/python3.8/site-packages/clin/models/shared.py", line 137, in from_manifest
    raise ValueError("Required field `kind` not found")
ValueError: Required field `kind` not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dlippok/.local/lib/python3.8/site-packages/clin/run.py", line 88, in apply
    envelope = load_manifest(Path(file), DEFAULT_YAML_LOADER, os.environ)
  File "/home/dlippok/.local/lib/python3.8/site-packages/clin/yamlops.py", line 166, in load_manifest
    raise YamlInvalidFormatError(file_path, str(e))
  File "/home/dlippok/.local/lib/python3.8/site-packages/clin/yamlops.py", line 150, in __init__
    super(file)
TypeError: super() argument 1 must be type, not PosixPath
```

This PR fixes the exception handling, so that no uncaught exception is thrown. This results in following output:

```
$ clin apply -e staging --token "$TOKEN" ./manifest-without-kind.yaml 
Required field `kind` not found in ./manifest-without-kind.yaml
```

## Types of Changes

- Bug fix (non-breaking change which fixes an issue)
