### PR TITLE
Add support for EventOwnerSelector

### DIFF
--- a/clin/models/event_type.py
+++ b/clin/models/event_type.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional
 
 from colorama import Fore
 
@@ -9,6 +10,7 @@ from clin.models.shared import (
     Cleanup,
     Category,
     Entity,
+    EventOwnerSelector,
     Kind,
     Audience,
     Partitioning,
@@ -26,6 +28,7 @@ class EventType(Entity):
     cleanup: Cleanup
     schema: Schema
     auth: ReadWriteAuth
+    event_owner_selector: Optional[EventOwnerSelector]
 
     def __str__(self) -> str:
         return f"event type {Fore.BLUE}{self.name}{Fore.RESET}"
@@ -36,6 +39,10 @@ class EventType(Entity):
 
     @staticmethod
     def from_spec(spec: dict[str, any]) -> EventType:
+        def maybe_event_owner_selector():
+            maybe = spec.get("eventOwnerSelector", None)
+            return EventOwnerSelector.from_spec(maybe) if maybe else None
+
         return EventType(
             name=spec["name"],
             category=Category(spec["category"]),
@@ -45,9 +52,17 @@ class EventType(Entity):
             cleanup=Cleanup.from_spec(spec["cleanup"]),
             schema=Schema.from_spec(spec["schema"]),
             auth=ReadWriteAuth.from_spec(spec["auth"]),
+            event_owner_selector=maybe_event_owner_selector(),
         )
 
     def to_spec(self) -> dict[str, any]:
+        def maybe_event_owner_selector():
+            return (
+                self.event_owner_selector.to_spec()
+                if self.event_owner_selector
+                else None
+            )
+
         return {
             "name": self.name,
             "category": str(self.category),
@@ -57,4 +72,5 @@ class EventType(Entity):
             "cleanup": self.cleanup.to_spec(),
             "schema": self.schema.to_spec(),
             "auth": self.auth.to_spec() if self.auth else {},
+            "eventOwnerSelector": maybe_event_owner_selector(),
         }

--- a/clin/models/shared.py
+++ b/clin/models/shared.py
@@ -39,6 +39,32 @@ class Kind(str, Enum):
 
 
 @dataclass
+class EventOwnerSelector:
+    @unique
+    class Type(str, Enum):
+        PATH = "path"
+        STATIC = "static"
+
+        def __str__(self) -> str:
+            return str(self.value)
+
+    type: Type
+    name: str
+    value: str
+
+    @staticmethod
+    def from_spec(spec: dict[str, any]) -> EventOwnerSelector:
+        return EventOwnerSelector(
+            type=EventOwnerSelector.Type(spec["type"]),
+            name=spec["name"],
+            value=spec["value"],
+        )
+
+    def to_spec(self) -> dict[str, any]:
+        return {"type": str(self.type), "name": self.name, "value": self.value}
+
+
+@dataclass
 class Cleanup:
     @unique
     class Policy(str, Enum):

--- a/clin/processor.py
+++ b/clin/processor.py
@@ -16,7 +16,7 @@ from clin.clients.nakadi_sql import NakadiSql, sql_query_to_payload
 from clin.config import AppConfig
 from clin.models.auth import ReadWriteAuth, ReadOnlyAuth
 from clin.models.event_type import EventType
-from clin.models.shared import Kind, Envelope, Entity
+from clin.models.shared import Kind, Envelope, Entity, EventOwnerSelector
 from clin.models.sql_query import SqlQuery
 from clin.models.subscription import Subscription
 from clin.utils import pretty_yaml, pretty_json
@@ -175,6 +175,7 @@ class Processor:
                         ReadOnlyAuth: convert_to_spec,
                         ReadWriteAuth: convert_to_spec,
                         EventType: convert_to_spec,
+                        EventOwnerSelector: convert_to_spec,
                         SqlQuery: convert_to_spec,
                         Subscription: convert_to_spec,
                         Entity: convert_to_spec,


### PR DESCRIPTION
Adds support for defining the `EventOwnerSelector`

## Description

Adds support for defining the `EventOwnerSelector` field on event types,
see https://nakadi.io/manual.html#definition_EventOwnerSelector for
documentation on this field. Attemps to be backwards compatbile to spec
files without the field yet.

## Types of Changes

- New feature (non-breaking change which adds functionality)
