### PR TITLE
Validate environment

### DIFF
--- a/clin/run.py
+++ b/clin/run.py
@@ -245,6 +245,9 @@ def dump(
             logging.error(f"Environment not found in configuration: {env}")
             exit(-1)
 
+        if not config.environments[env].nakadi_sql_url:
+            logging.warning(f"Configuration key nakadi_sql_url was not defined for your environment {env}. You won't be able to dump Nakadi SQL.")
+
         nakadi = Nakadi(config.environments[env].nakadi_url, token)
         entity = nakadi.get_event_type(event_type)
 
@@ -261,9 +264,9 @@ def dump(
         )
 
         if output.lower() == "yaml":
-            logging.info(pretty_yaml(payload))
+            print(pretty_yaml(payload))
         elif output.lower() == "json":
-            logging.info(pretty_json(payload))
+            print(pretty_json(payload))
         else:
             logging.error("Invalid output format: %s", output)
             exit(-1)

--- a/clin/utils.py
+++ b/clin/utils.py
@@ -35,7 +35,7 @@ def ensure_flat_list(val) -> list:
 
 
 def configure_logging(verbose: bool):
-    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
+    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
     if verbose:
         logging.getLogger().setLevel(logging.DEBUG)
     logging.getLogger("requests").setLevel(logging.WARNING)

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,8 +71,10 @@ override/replace another.
 environments:
     staging:
         nakadi_url: https://nakadi-staging.local
+        nakadi_sql_url: https://nakadi-sql-staging.local
     production:
         nakadi_url: https://nakadi-production.local
+        nakadi_sql_url: https://nakadi-sql-production.local
 ```
 
 ## Manifests format


### PR DESCRIPTION
# One-line summary

Display warning message when a dump message is used but Nakadi SQL URL is not specified.

## Description

Clin supports dumping both event definitions and Nakadi SQL definitions via common `dump` command. Nakadi SQL endpoint is separated from the messaging API and currently if the Nakadi SQL endpoint is not specified in the configuration Clin silently skips querying the SQL endpoint and goes directly to the messaging endpoint. This is misinterpreted by Nakadi backend and the returned result is an event definition instead of the SQL definition.

This behavior is misleading to the user of Clin that expects an SQL definition to be returned. In order to make the usage of Clin more interactive and friendly to the user, it will display a warning log line `Configuration key nakadi_sql_url was not defined for your environment {env}. You won't be able to dump Nakadi SQL.` when `dump` command is executed and the URL of the SQL endpoint was not configured.

Additionally `nakadi_sql_url` was added to the example configuration in the docs to make it clear that the configuration key is expected.

### Breaking changes

Until now, all log messages were written to `stdout`. In order to not pollute the output of the `dump` command with log messages for users who did not configure the SQL endpoint yet, all logs will be written to `stderr` instead. This can potentially break parsing of log messages for users who rely on the fact that they are written to `stdout`. 

## Types of Changes

- Refactor/improvements
- Documentation

## Tasks
_List of tasks you will do to complete the PR_

None

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes

None
