### PR TITLE
Allow creating queries with reparitioning

### DIFF
--- a/clin/clients/nakadi_sql.py
+++ b/clin/clients/nakadi_sql.py
@@ -120,7 +120,7 @@ def sql_query_to_payload(sql_query: SqlQuery) -> dict:
     }
 
     if sql_query.output_event_type.repartitioning:
-        payload["repartition_parameters"] = {
+        payload["output_event_type"]["repartition_parameters"] = {
             "number_of_partitions": sql_query.output_event_type.repartitioning.partition_count,
             "partition_strategy": str(
                 sql_query.output_event_type.repartitioning.strategy


### PR DESCRIPTION
# One-line summary
Allow create Nakadi queries with repartitioning

> Issue : #83: Repartitioning via nakadi SQL does not work. Key is in wrong place in payload

## Description

The PR fixes a bug that prevented creating Nakadi SQL queries with repartitioning.

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)

## Tasks
None

## Review
None

## Deployment Notes
None