### PR TITLE
missing partition_compaction_key_field in sql-query

### DIFF
--- a/clin/clients/nakadi_sql.py
+++ b/clin/clients/nakadi_sql.py
@@ -115,6 +115,7 @@ def sql_query_to_payload(sql_query: SqlQuery) -> dict:
             "cleanup_policy": str(sql_query.output_event_type.cleanup.policy),
             "retention_time": sql_query.output_event_type.cleanup.retention_time_days
             * MS_IN_DAY,
+            "partition_compaction_key_field": sql_query.output_event_type.partition_compaction_key_field
         },
         "authorization": auth_to_payload(sql_query.auth),
     }

--- a/clin/clients/nakadi_sql.py
+++ b/clin/clients/nakadi_sql.py
@@ -115,7 +115,7 @@ def sql_query_to_payload(sql_query: SqlQuery) -> dict:
             "cleanup_policy": str(sql_query.output_event_type.cleanup.policy),
             "retention_time": sql_query.output_event_type.cleanup.retention_time_days
             * MS_IN_DAY,
-            "partition_compaction_key_field": sql_query.output_event_type.partition_compaction_key_field
+            "partition_compaction_key_field": sql_query.output_event_type.partition_compaction_key_field,
         },
         "authorization": auth_to_payload(sql_query.auth),
     }

--- a/clin/models/sql_query.py
+++ b/clin/models/sql_query.py
@@ -16,6 +16,7 @@ class OutputEventType:
     audience: Audience
     repartitioning: Optional[Partitioning]
     cleanup: Cleanup
+    partition_compaction_key_field: str
 
     @staticmethod
     def from_spec(spec: dict[str, any]):
@@ -27,6 +28,7 @@ class OutputEventType:
             if "repartitioning" in spec
             else None,
             cleanup=Cleanup.from_spec(spec["cleanup"]),
+            partition_compaction_key_field=spec["partitionCompactionKeyField"]
         )
 
     def to_spec(self) -> dict[str, any]:
@@ -35,6 +37,7 @@ class OutputEventType:
             "owningApplication": self.owning_application,
             "audience": str(self.audience),
             "cleanup": self.cleanup.to_spec(),
+            "partitionCompactionKeyField": self.partition_compaction_key_field,
         }
 
         if self.repartitioning:

--- a/clin/models/sql_query.py
+++ b/clin/models/sql_query.py
@@ -28,7 +28,7 @@ class OutputEventType:
             if "repartitioning" in spec
             else None,
             cleanup=Cleanup.from_spec(spec["cleanup"]),
-            partition_compaction_key_field=spec["partitionCompactionKeyField"]
+            partition_compaction_key_field=spec["partitionCompactionKeyField"],
         )
 
     def to_spec(self) -> dict[str, any]:

--- a/docs/examples/single/sql-query.yaml
+++ b/docs/examples/single/sql-query.yaml
@@ -13,6 +13,12 @@ spec:
     cleanup:
       policy: delete
       retentionTimeDays: 2
+    partitionCompactionKeyField": product_logistics.metadata.partition_compaction_key
+    repartitioning:
+      strategy: hash
+      keys:
+        - important_key
+      partitionCount: 8
   auth:
     teams:
       admins:

--- a/docs/examples/single/sql-query.yaml
+++ b/docs/examples/single/sql-query.yaml
@@ -34,3 +34,4 @@ spec:
       admins:
       readers:
         - your_application_id
+


### PR DESCRIPTION
# One-line summary

> Issue : #114 

## Description
Whenever I try to create a sql-query, I got status code 400 as the partition_compaction_key_field is missing.
```Can not process sql query {{name}}: Nakadi error during creation of sql query '{{name}}:': 400 - {"detail":"Compacted output event type requires partition_compaction_key","status":400,"title":"Bad Request"}```

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)
- Documentation / non-code

## Review
