### PR TITLE
sort yaml files returned to behave as db migrations

### DIFF
--- a/clin/clinfile.py
+++ b/clin/clinfile.py
@@ -44,7 +44,7 @@ def calculate_scope(
                     f"Specified path 'f{source.absolute()}' is not found for process '{proc_id}'"
                 )
 
-            manifests_files += chain(source.glob("*.yml"), source.glob("*.yaml"))
+            manifests_files += sorted(chain(source.glob("*.yml"), source.glob("*.yaml")))
             if not manifests_files:
                 logging.warning(
                     "No manifests found for process '%s' in '%s'",

--- a/clin/clinfile.py
+++ b/clin/clinfile.py
@@ -44,7 +44,9 @@ def calculate_scope(
                     f"Specified path 'f{source.absolute()}' is not found for process '{proc_id}'"
                 )
 
-            manifests_files += sorted(chain(source.glob("*.yml"), source.glob("*.yaml")))
+            manifests_files += sorted(
+                chain(source.glob("*.yml"), source.glob("*.yaml"))
+            )
             if not manifests_files:
                 logging.warning(
                     "No manifests found for process '%s' in '%s'",


### PR DESCRIPTION
# One-line summary

> Issue : #118 (only if appropriate)

## Description
so this source.glob("*.yaml") method doesn't return the yaml files ordered, so in our case, we have dependent nakadi sql queries that should be executed in the right order.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Refactor/improvements
