### PR TITLE
Revert "Bump abatilo/actions-poetry from 2.1.5 to 2.2.0 (#134)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install poetry
-        uses: abatilo/actions-poetry@v2.2.0
+        uses: abatilo/actions-poetry@v2.1.5
 
       - name: Set version
         run: |


### PR DESCRIPTION
This reverts commit 82fd008c72553d7d36b2f099760e7dac32845151.

# One-line summary

Fixes builds for dependabot updates

## Description

It seems that after upgrading `actions-poetry` to `2.2.0` dependabot creates poetry.lock files that removes important dependencies for many of the packages used in the project. This PR attempts to fix it by reverting the mentioned upgrade.

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
